### PR TITLE
Retrieve card due date

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,6 +141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "num-integer 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-traits 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.110 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.43 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1535,6 +1536,7 @@ dependencies = [
 name = "tro"
 version = "1.30.0"
 dependencies = [
+ "chrono 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "colored 1.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "console 0.11.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ rustyline = "~6.1.2"
 # see https://github.com/mitsuhiko/console/issues/66
 console = "=0.11.2"
 dialoguer = "0.6"
+chrono = { version = "0.4", features = ["serde"] }
 
 [dev-dependencies]
 mockito = "~0.25.0"

--- a/src/trello/card.rs
+++ b/src/trello/card.rs
@@ -4,6 +4,7 @@ use crate::label::Label;
 use crate::trello_error::TrelloError;
 use crate::trello_object::{Renderable, TrelloObject};
 
+use chrono::{DateTime, Utc};
 use colored::Colorize;
 use serde::Deserialize;
 use std::str::FromStr;
@@ -20,6 +21,7 @@ pub struct Card {
     pub closed: bool,
     pub url: String,
     pub labels: Option<Vec<Label>>,
+    pub due: Option<DateTime<Utc>>,
 }
 
 impl TrelloObject for Card {
@@ -32,7 +34,7 @@ impl TrelloObject for Card {
     }
 
     fn get_fields() -> &'static [&'static str] {
-        &["id", "name", "desc", "labels", "closed", "url"]
+        &["id", "name", "desc", "labels", "closed", "due", "url"]
     }
 }
 
@@ -136,6 +138,7 @@ impl Card {
             url: String::from(url),
             labels,
             closed: false,
+            due: None,
         }
     }
 


### PR DESCRIPTION
Exposes the card due date in the API but does not attempt to show the due date
in tro since this needs more discussion. Does not attempt to implement create
or update due date, but these may come in a follow-up patch after testing.

Resolves: #13

Signed-off-by: Christopher Obbard <chris@64studio.com>