### PR TITLE
Re-use reqwest client for better performance

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use std::io::{Read, Write};
 use std::process;
 use std::{thread, time};
 use trello::Renderable;
-use trello::{Card, CardContents, Client, TrelloError, TrelloObject};
+use trello::{Card, CardContents, TrelloClient, TrelloError, TrelloObject};
 
 pub fn multiselect_trello_object<T: TrelloObject + Renderable + PartialEq>(
     objects: &[T],
@@ -62,7 +62,7 @@ pub fn get_input(text: &str) -> Result<String, rustyline::error::ReadlineError> 
 ///
 /// This function will upload any changes written by the editor to Trello. This includes
 /// when the editor is not closed but content is saved.
-pub fn edit_card(client: &Client, card: &Card) -> Result<(), Box<dyn Error>> {
+pub fn edit_card(client: &TrelloClient, card: &Card) -> Result<(), Box<dyn Error>> {
     let mut file = tempfile::Builder::new().suffix(".md").tempfile()?;
     let editor_env = env::var("EDITOR").unwrap_or_else(|_| String::from("vi"));
 

--- a/src/find.rs
+++ b/src/find.rs
@@ -2,7 +2,7 @@ use clap::ArgMatches;
 use regex::RegexBuilder;
 use std::cmp::Ordering;
 use thiserror::Error;
-use trello::{Board, Card, Client, List, TrelloObject};
+use trello::{Board, Card, List, TrelloClient, TrelloObject};
 
 #[derive(Debug, PartialEq, Error)]
 pub enum FindError {
@@ -84,7 +84,7 @@ pub fn get_trello_params<'a>(matches: &'a ArgMatches) -> TrelloParams<'a> {
 }
 
 pub fn get_trello_object(
-    client: &Client,
+    client: &TrelloClient,
     params: &TrelloParams,
 ) -> Result<TrelloResult, Box<dyn std::error::Error>> {
     let board_name = match params.board_name {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use simplelog::{CombinedLogger, Config, LevelFilter, TermLogger, TerminalMode};
 use std::env;
 use std::error::Error;
 use std::process;
-use trello::Client;
+use trello::{ClientConfig, TrelloClient};
 
 fn main() {
     if let Err(error) = start() {
@@ -162,7 +162,7 @@ https://help.trello.com/article/808-searching-for-cards-all-boards")
         return Ok(());
     }
 
-    let client = match Client::load_config() {
+    let config = match ClientConfig::load_config() {
         Ok(client) => client,
         Err(_) => {
             println!("Unable to load client configuration");
@@ -170,6 +170,7 @@ https://help.trello.com/article/808-searching-for-cards-all-boards")
             return Ok(());
         }
     };
+    let client = TrelloClient::new(config);
 
     debug!("Loaded configuration: {:?}", client);
 

--- a/src/test_find.rs
+++ b/src/test_find.rs
@@ -1,6 +1,6 @@
 use crate::find::*;
 use std::error::Error;
-use trello::{Board, Card, Client, List};
+use trello::{Board, Card, ClientConfig, List, TrelloClient};
 
 type TestResult = Result<(), Box<dyn Error>>;
 
@@ -17,7 +17,8 @@ mod test_get_trello_object {
             card_name: None,
             ignore_case: false,
         };
-        let client = Client::new("", "", "");
+        let config = ClientConfig::new("", "", "");
+        let client = TrelloClient::new(config);
 
         let result = get_trello_object(&client, &params)?;
         let expected = TrelloResult {
@@ -64,7 +65,8 @@ mod test_get_trello_object {
             card_name: None,
             ignore_case: true,
         };
-        let client = Client::new(&mockito::server_url(), "token", "key");
+        let config = ClientConfig::new(&mockito::server_url(), "token", "key");
+        let client = TrelloClient::new(config);
 
         let result = get_trello_object(&client, &params)?;
         let expected = TrelloResult {

--- a/src/trello/member.rs
+++ b/src/trello/member.rs
@@ -1,6 +1,6 @@
 use serde::Deserialize;
 
-use crate::client::Client;
+use crate::client::TrelloClient;
 use crate::trello_error::TrelloError;
 
 type Result<T> = std::result::Result<T, TrelloError>;
@@ -14,9 +14,9 @@ pub struct Member {
 }
 
 impl Member {
-    pub fn me(client: &Client) -> Result<Member> {
-        let url = client.get_trello_url("/1/members/me/", &[])?;
+    pub fn me(client: &TrelloClient) -> Result<Member> {
+        let url = client.config.get_trello_url("/1/members/me/", &[])?;
 
-        Ok(reqwest::get(url)?.error_for_status()?.json()?)
+        Ok(client.client.get(url).send()?.error_for_status()?.json()?)
     }
 }

--- a/src/trello/mod.rs
+++ b/src/trello/mod.rs
@@ -19,7 +19,7 @@ mod tests;
 pub use attachment::Attachment;
 pub use board::Board;
 pub use card::{Card, CardContents};
-pub use client::Client;
+pub use client::{ClientConfig, TrelloClient};
 pub use formatting::{header, title};
 pub use label::Label;
 pub use list::List;

--- a/src/trello/search.rs
+++ b/src/trello/search.rs
@@ -1,6 +1,6 @@
 use super::board::Board;
 use super::card::Card;
-use super::client::Client;
+use super::client::TrelloClient;
 use super::trello_error::TrelloError;
 use super::trello_object::TrelloObject;
 
@@ -35,7 +35,11 @@ pub struct SearchResult {
 
 /// Implements the Trello Search API
 /// https://developer.atlassian.com/cloud/trello/rest/api-group-search/#api-search-get
-pub fn search(client: &Client, search_term: &str, options: &SearchOptions) -> Result<SearchResult> {
+pub fn search(
+    client: &TrelloClient,
+    search_term: &str,
+    options: &SearchOptions,
+) -> Result<SearchResult> {
     let partial = options.partial.to_string();
     let card_fields = Card::get_fields().join(",");
     let board_fields = Board::get_fields().join(",");
@@ -60,7 +64,7 @@ pub fn search(client: &Client, search_term: &str, options: &SearchOptions) -> Re
         params.push(("boards_limit", &boards_limit));
     }
 
-    let url = client.get_trello_url("/1/search/", &params)?;
+    let url = client.config.get_trello_url("/1/search/", &params)?;
 
-    Ok(reqwest::get(url)?.error_for_status()?.json()?)
+    Ok(client.client.get(url).send()?.error_for_status()?.json()?)
 }

--- a/src/trello/tests/test_attachment.rs
+++ b/src/trello/tests/test_attachment.rs
@@ -17,7 +17,9 @@ fn test_get_all() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "my-token", "sekret");
+    let config = ClientConfig::new(&mockito::server_url(), "my-token", "sekret");
+    let client = TrelloClient::new(config);
+
     let result = Attachment::get_all(&client, "FOO-CARD")?;
 
     let expected = [Attachment {
@@ -50,7 +52,8 @@ fn test_apply() -> Result<()> {
 
     let path = file1.path().to_str().unwrap();
 
-    let client = Client::new(&mockito::server_url(), "TOKEN", "KEY");
+    let config = ClientConfig::new(&mockito::server_url(), "TOKEN", "KEY");
+    let client = TrelloClient::new(config);
 
     let result = Attachment::apply(&client, "CARD-23", path)?;
 

--- a/src/trello/tests/test_board.rs
+++ b/src/trello/tests/test_board.rs
@@ -117,7 +117,9 @@ fn test_create() -> Result<()> {
         )
         .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = Board::create(&client, "MYTESTBOARD")?;
     let expected = Board::new(
         "231dgfe4r343",
@@ -149,7 +151,8 @@ fn test_update() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
 
     let mut board = Board::new("MY-BOARD-ID", "TODO", None, "");
     board.closed = true;
@@ -176,7 +179,9 @@ fn test_get_all() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-secret-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-secret-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = Board::get_all(&client)?;
     let expected = vec![
         Board::new("abc-def", "TODO", None, "bit.ly/1"),
@@ -205,7 +210,9 @@ fn test_get() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "TOKEN", "KEY");
+    let config = ClientConfig::new(&mockito::server_url(), "TOKEN", "KEY");
+    let client = TrelloClient::new(config);
+
     let result = Board::get(&client, "some-board-id")?;
     let expected = Board::new(
         "some-board-id",

--- a/src/trello/tests/test_card.rs
+++ b/src/trello/tests/test_card.rs
@@ -111,7 +111,9 @@ fn test_get() -> Result<()> {
         )
         .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = Card::get(&client, "CARD-FOO")?;
 
     let expected = Card::new(
@@ -145,7 +147,9 @@ fn test_create() -> Result<()> {
         )
         .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = Card::create(
         &client,
         "FOOBAR",
@@ -181,7 +185,8 @@ fn test_update() -> Result<()> {
         )
         .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
 
     let mut card = Card::new(
         "MY-CARD-ID",
@@ -228,7 +233,9 @@ fn test_get_all() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-secret-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-secret-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = Card::get_all(&client, "DEADBEEF")?;
     let expected = vec![
         Card::new(

--- a/src/trello/tests/test_label.rs
+++ b/src/trello/tests/test_label.rs
@@ -16,7 +16,9 @@ fn test_get_all() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = Label::get_all(&client, "123-456")?;
     let expected = vec![
         Label::new("1", "Tech", "purple"),
@@ -38,7 +40,8 @@ fn test_apply() -> Result<()> {
     .with_body(json!({}).to_string())
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
 
     Label::apply(&client, "SOME-CARD-ID", "MY-LABEL-ID")?;
 
@@ -54,7 +57,8 @@ fn test_remove() -> Result<()> {
     .with_status(200)
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
 
     Label::remove(&client, "FOO-CARD", "BAR-LABEL")?;
 

--- a/src/trello/tests/test_list.rs
+++ b/src/trello/tests/test_list.rs
@@ -65,7 +65,9 @@ fn test_create() -> Result<()> {
         )
         .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = List::create(&client, "LEONSK", "Today")?;
     let expected = List::new("MTLDA", "Today", None);
     assert_eq!(result, expected);
@@ -87,7 +89,8 @@ fn test_update() -> Result<()> {
         )
         .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
 
     let mut list = List::new("MY-LIST-ID", "Today", None);
     list.closed = true;
@@ -113,7 +116,9 @@ fn test_get_all() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = List::get_all(&client, "some-board-id", false)?;
     let expected = vec![
         List::new("823-123", "Red", None),
@@ -146,7 +151,9 @@ fn test_get_all_with_cards() -> Result<()> {
     )
     .create();
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = List::get_all(&client, "some-board-id", true)?;
     let expected = vec![
         List::new("823-123", "Red", Some(vec![])),

--- a/src/trello/tests/test_search.rs
+++ b/src/trello/tests/test_search.rs
@@ -28,7 +28,9 @@ fn test_empty() -> Result<()> {
         partial: false,
     };
 
-    let client = Client::new(&mockito::server_url(), "some-token", "some-key");
+    let config = ClientConfig::new(&mockito::server_url(), "some-token", "some-key");
+    let client = TrelloClient::new(config);
+
     let result = search(&client, "foo", &options)?;
 
     let expected = SearchResult {


### PR DESCRIPTION
Improve performance of subcommands by re-using reqwest::Client instead of using a new client each time a network request is performed as suggested in the documentation.

before
```
$ time tro show todo
tro show todo  0.06s user 0.02s system 5% cpu 1.369 total
```

after
```
$ time target/release/tro show todo
target/release/tro show todo  0.02s user 0.01s system 2% cpu 0.919 total
```