### PR TITLE
feat: move subcommand

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -60,6 +60,13 @@ fn start() -> Result<(), Box<dyn Error>> {
             (@arg label_filter: -f --filter +takes_value "Filter by label")
             (@arg interactive: -i --interactive "Enables interactive mode")
         )
+        (@subcommand move =>
+            (about: "Move a card to a different list")
+            (@arg board_name: +required "Board Name")
+            (@arg list_name: +required "List Name")
+            (@arg card_name: +required "Card Name")
+            (@arg new_list_name: +required "New List Name")
+        )
         (@subcommand search =>
             (about: "Search Trello cards")
             (long_about: "
@@ -181,6 +188,8 @@ https://help.trello.com/article/808-searching-for-cards-all-boards")
         subcommands::me_subcommand(&client, &matches)?;
     } else if let Some(matches) = matches.subcommand_matches("show") {
         subcommands::show_subcommand(&client, &matches)?;
+    } else if let Some(matches) = matches.subcommand_matches("move") {
+        subcommands::move_subcommand(&client, &matches)?;
     } else if let Some(matches) = matches.subcommand_matches("search") {
         subcommands::search_subcommand(&client, &matches)?;
     } else if let Some(matches) = matches.subcommand_matches("attach") {

--- a/src/subcommands.rs
+++ b/src/subcommands.rs
@@ -137,6 +137,38 @@ pub fn show_subcommand(client: &TrelloClient, matches: &ArgMatches) -> Result<()
     Ok(())
 }
 
+pub fn move_subcommand(client: &TrelloClient, matches: &ArgMatches) -> Result<()> {
+    debug!("Running move subcommand with {:?}", matches);
+
+    let params = find::get_trello_params(matches);
+    let result = find::get_trello_object(client, &params)?;
+
+    let new_list_name = matches
+        .value_of("new_list_name")
+        .ok_or("Missing new list name")?;
+
+    let board = result.board.ok_or("Unable to retrieve board")?;
+    let card = result.card.ok_or("Unable to retrieve card")?;
+    let list = result
+        .list
+        .ok_or("Unable to retrieve list. Wildcards are currently unsupported with move")?;
+
+    let board_lists = board.lists.as_ref().ok_or("Missing target board lists")?;
+
+    let new_list = find::get_object_by_name(board_lists, new_list_name, true)?;
+
+    Card::change_list(client, &card.id, &new_list.id)?;
+
+    println!(
+        "Moved '{}' from '{}' to '{}'",
+        card.name.green(),
+        list.name.green(),
+        new_list.name.green()
+    );
+
+    Ok(())
+}
+
 pub fn open_subcommand(client: &TrelloClient, matches: &ArgMatches) -> Result<()> {
     debug!("Running open subcommand with {:?}", matches);
 

--- a/src/trello/card.rs
+++ b/src/trello/card.rs
@@ -215,6 +215,24 @@ impl Card {
             .json()?)
     }
 
+    // Moves a card to the list with the specified id
+    pub fn change_list(client: &TrelloClient, card_id: &str, list_id: &str) -> Result<()> {
+        let url = client
+            .config
+            .get_trello_url(&format!("/1/cards/{}/", card_id), &[])?;
+
+        let params = [("idList", list_id)];
+
+        client
+            .client
+            .put(url)
+            .form(&params)
+            .send()?
+            .error_for_status()?;
+
+        Ok(())
+    }
+
     pub fn get_all(client: &TrelloClient, list_id: &str) -> Result<Vec<Card>> {
         let url = client.config.get_trello_url(
             &format!("/1/lists/{}/cards/", list_id),


### PR DESCRIPTION
Add a basic implementation of the move subcommand

Currently does not support the wildcard operator for specifying the original list pattern