### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ keywords = ["trello"]
 categories = ["command-line-utilities"]
 readme = "README.rst"
 license = "GPL-3.0-only"
-homepage = "https://www.github.com/MichaelAquilina/tro"
-repository = "https://www.github.com/MichaelAquilina/tro.git"
+homepage = "https://github.com/MichaelAquilina/tro"
+repository = "https://github.com/MichaelAquilina/tro.git"
 
 [lib]
 name = "trello"


### PR DESCRIPTION
GitHub redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96